### PR TITLE
Fix multiple comments/illustration bug

### DIFF
--- a/src/lib/util/editor/quill.ts
+++ b/src/lib/util/editor/quill.ts
@@ -44,6 +44,8 @@ export class QuillEditor extends Quill {
 	comments: { [key: string]: Comment } = {};
 	illustrations: { [key: string]: Illustration } = {};
 	selectedDelta: Delta | undefined = undefined;
+	selectedRange: { index: number; length: number } | undefined | null = undefined;
+	oldSelectedRange: { index: number; length: number } | undefined | null = undefined;
 	ops: Op[] | undefined;
 	page: Page;
 	chapter: HydratedDocument<ChapterProperties> | undefined;
@@ -244,6 +246,8 @@ export class QuillEditor extends Quill {
 		}
 
 		const delta = this.getContents(range.index, 1);
+		this.oldSelectedRange = oldRange;
+		this.selectedRange = range;
 		this.selectedDelta = delta;
 
 		if (!this.isComment(delta.ops[0]) && !this.isIllustration(delta.ops[0])) {

--- a/src/routes/editor/[bookID]/+page.svelte
+++ b/src/routes/editor/[bookID]/+page.svelte
@@ -501,6 +501,7 @@
 	function removeComment(id: string) {
 		let editor = document.getElementById('editor');
 		quill.removeComment(id, editor);
+		quill.oldSelectedRange = null; // reset the old range
 	}
 
 	/**
@@ -536,6 +537,8 @@
 					toastStore.trigger(successUploadToast);
 				}
 			});
+
+		quill.oldSelectedRange = null; // reset the old range
 	}
 
 	/**
@@ -563,8 +566,15 @@
 	}
 
 	function commentAddClick() {
-		if (!quill.selectedContainsComment() && !quill.selectedContainsIllustration())
+
+		if (quill.oldSelectedRange === quill.selectedRange) {
+			return; // same range is selected
+		}
+
+		if (!quill.selectedContainsComment() && !quill.selectedContainsIllustration()){
 			quill.getModule('comment').addComment(' ');
+			quill.oldSelectedRange = quill.selectedRange; // update the old selected range
+		}
 
 		if (quill.selectedContainsIllustration()) {
 			drawerStore.open(drawerSettings);
@@ -581,12 +591,18 @@
 	 * Adds an illustration to the quill
 	 */
 	function illustrationAddClick() {
+
+		if (quill.oldSelectedRange === quill.selectedRange) {
+			return; // same range is selected
+		}
+
 		if (!quill.selectedContainsComment() && !quill.selectedContainsIllustration()) {
 			quill.getModule('illustration').addIllustration({
 				src: '',
 				alt: '',
 				caption: ''
 			});
+			quill.oldSelectedRange = quill.selectedRange; // update the old selected range
 		}
 
 		if (quill.selectedContainsComment()) {


### PR DESCRIPTION
Added currently selected range variables to quill
Comments cannot be spam added to ranges that already contain comments. The same is true for illustrations.