### PR TITLE
Feature: Add multi archiving

### DIFF
--- a/src/lib/components/studio/ArchiveSelectedButton.svelte
+++ b/src/lib/components/studio/ArchiveSelectedButton.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { HydratedDocument } from 'mongoose';
+
+	export let selected: HydratedDocument<any>;
+	export let archiveMode: boolean;
+	export let openUnarchiveModal: (a: any) => void;
+	export let openArchiveModal: (a: any) => void;
+</script>
+
+<button
+	class="btn btn-sm variant-filled"
+	disabled={selected.length === 0}
+	on:click={() => (archiveMode ? openUnarchiveModal(selected) : openArchiveModal(selected))}
+>
+	{archiveMode ? 'Unarchive' : 'Archive'} Selected
+</button>

--- a/src/lib/db/db-data.test.ts
+++ b/src/lib/db/db-data.test.ts
@@ -99,7 +99,8 @@ test(
 						description: `Storyline ${l} description`,
 						book: newBook._id,
 						parent: storylines[0]._id,
-						parentChapter: getRandomElement(chapters)._id
+						parentChapter: getRandomElement(chapters)._id,
+						imageURL: `https://picsum.photos/id/${Math.floor(Math.random() * 1001)}/500/1000`
 					});
 					for (let k = 0; k < CHAPTERS_PER_STORYLINE; k++) {
 						await createChapter(

--- a/src/lib/documents/digital-products/chapter.ts
+++ b/src/lib/documents/digital-products/chapter.ts
@@ -191,21 +191,18 @@ export class ChapterBuilder extends DocumentBuilder<HydratedDocument<ChapterProp
 		return chapter;
 	}
 
-	async setArchived(): Promise<HydratedDocument<ChapterProperties>> {
-		const chapter = await Chapter.findOneAndUpdate(
-			{ _id: this._chapterProperties._id },
-			{ archived: this._chapterProperties.archived },
-			{
-				new: true,
-				userID: this._sessionUserID
-			}
-		);
+	async setArchived(ids: string[]): Promise<boolean> {
+		const acknowledged = (
+			await Chapter.updateMany(
+				{ _id: { $in: ids }, user: this._chapterProperties.user },
+				{ archived: this._chapterProperties.archived },
+				{
+					userID: this._sessionUserID
+				}
+			)
+		).acknowledged;
 
-		if (chapter) {
-			return chapter;
-		}
-
-		throw new Error("Couldn't update chapter");
+		return acknowledged;
 	}
 
 	async build(): Promise<HydratedDocument<ChapterProperties>> {

--- a/src/lib/tests/chapters.test.ts
+++ b/src/lib/tests/chapters.test.ts
@@ -186,7 +186,7 @@ describe('chapters', () => {
 		);
 	});
 
-	test('toggling archived status', async () => {
+	test('updating archived status', async () => {
 		const session = createTestSession(testUserOne);
 		await createDBUser(session);
 		const book = await createBook(session);
@@ -199,14 +199,33 @@ describe('chapters', () => {
 			})
 		).result[0];
 
-		const chapter = await createChapter(session, 'Chapter 1', 'My chapter 1', storyline);
+		const chapterOne = await createChapter(session, 'Chapter 1', 'My chapter 1', storyline);
+		const chapterTwo = await createChapter(
+			session,
+			'Chapter 2',
+			'My chapter 2',
+			storyline,
+			chapterOne._id
+		);
+		const chapterThree = await createChapter(
+			session,
+			'Chapter 3',
+			'My chapter 3',
+			storyline,
+			chapterTwo._id
+		);
 
-		expect(chapter.archived).toEqual(false);
-		expect(
-			(await caller.chapters.setArchived({ id: chapter._id, archived: true })).archived
-		).toEqual(true);
-		expect(
-			(await caller.chapters.setArchived({ id: chapter._id, archived: false })).archived
-		).toEqual(false);
+		// Check archived before updating
+		expect(chapterOne.archived).toEqual(false);
+		expect(chapterTwo.archived).toEqual(false);
+		expect(chapterThree.archived).toEqual(false);
+
+		// Archive chapters one and two
+		await caller.chapters.setArchived({ ids: [chapterOne._id, chapterTwo._id], archived: true });
+
+		// Check archived changed only for chapters one and two
+		expect((await caller.chapters.getById({ id: chapterOne._id })).archived).toEqual(true);
+		expect((await caller.chapters.getById({ id: chapterTwo._id })).archived).toEqual(true);
+		expect((await caller.chapters.getById({ id: chapterThree._id })).archived).toEqual(false);
 	});
 });

--- a/src/lib/trpc/routes/books.ts
+++ b/src/lib/trpc/routes/books.ts
@@ -66,14 +66,14 @@ export const books = t.router({
 		.use(auth)
 		.input(setArchived)
 		.mutation(async ({ input, ctx }) => {
-			const bookBuilder = new BookBuilder(input.id)
+			const bookBuilder = new BookBuilder()
 				.sessionUserID(ctx.session!.user.id)
 				.userID(ctx.session!.user.id)
 				.archived(input.archived);
 
-			const book = await bookBuilder.setArchived();
+			const acknowledged = await bookBuilder.setArchived(input.ids);
 
-			return book;
+			return acknowledged;
 		}),
 
 	getBooksByUserID: t.procedure

--- a/src/lib/trpc/routes/chapters.ts
+++ b/src/lib/trpc/routes/chapters.ts
@@ -82,14 +82,14 @@ export const chapters = t.router({
 		.use(auth)
 		.input(setArchived)
 		.mutation(async ({ input, ctx }) => {
-			const chapterBuilder = new ChapterBuilder(input.id)
+			const chapterBuilder = new ChapterBuilder()
 				.sessionUserID(ctx.session!.user.id)
 				.userID(ctx.session!.user.id)
 				.archived(input.archived);
 
-			const chapter = await chapterBuilder.setArchived();
+			const acknowledged = await chapterBuilder.setArchived(input.ids);
 
-			return chapter;
+			return acknowledged;
 		}),
 
 	create: t.procedure

--- a/src/lib/trpc/routes/storylines.ts
+++ b/src/lib/trpc/routes/storylines.ts
@@ -74,14 +74,14 @@ export const storylines = t.router({
 		.use(auth)
 		.input(setArchived)
 		.mutation(async ({ input, ctx }) => {
-			const storylineBuilder = new StorylineBuilder(input.id)
+			const storylineBuilder = new StorylineBuilder()
 				.sessionUserID(ctx.session!.user.id)
 				.userID(ctx.session!.user.id)
 				.archived(input.archived);
 
-			const storyline = await storylineBuilder.setArchived();
+			const acknowledged = await storylineBuilder.setArchived(input.ids);
 
-			return storyline;
+			return acknowledged;
 		}),
 
 	create: t.procedure

--- a/src/lib/trpc/schemas/shared.ts
+++ b/src/lib/trpc/schemas/shared.ts
@@ -14,6 +14,6 @@ export const search = z.object({
 });
 
 export const setArchived = z.object({
-	id: z.string(),
+	ids: z.array(z.string()),
 	archived: z.boolean()
 });

--- a/src/routes/(landing)/home/+page.svelte
+++ b/src/routes/(landing)/home/+page.svelte
@@ -2,9 +2,8 @@
 	import { Accordion, AccordionItem } from '@skeletonlabs/skeleton';
 	import type { HydratedDocument } from 'mongoose';
 	import { Icon } from 'svelte-awesome';
-	import { arrowUp, filter } from 'svelte-awesome/icons';
+	import { filter } from 'svelte-awesome/icons';
 
-	import type { PageData } from './$types';
 	import { page } from '$app/stores';
 	import Container from '$lib/components/Container.svelte';
 	import BookPreview from '$lib/components/book/BookPreview.svelte';
@@ -16,8 +15,7 @@
 	import { browser } from '$app/environment';
 	import { debouncedScrollCallback } from '$lib/util/debouncedCallback';
 	import ScrollToTopButton from '$lib/components/util/ScrollToTopButton.svelte';
-
-	export let data: PageData;
+	import InfoHeader from '$lib/components/InfoHeader.svelte';
 
 	const SEARCH_DEBOUNCE_SECONDS = 1.0;
 	// Only "recommended" is implemented for now
@@ -127,7 +125,7 @@
 
 <svelte:window on:scroll={loadMore} />
 
-<Container class="w-full">
+<Container class="w-full min-h-screen">
 	<div class="sticky top-[4.7rem] z-[2] flex flex-col gap-1">
 		<input
 			class="input text-sm h-8"
@@ -199,34 +197,28 @@
 	</div>
 
 	{#if $getBooksInfinite.isLoading}
-		<div class="h-screen flex justify-center items-center">
+		<div class="h-screen flex justify-center items-center pb-32">
 			<LoadingSpinner />
 		</div>
 	{:else if $getBooksInfinite.isError}
-		<div class="mt-8 text-center space-y-8 h-screen">
-			<div>
-				<p class="text-6xl">🤕</p>
-				<h4>Something went wrong while fetching books!</h4>
-				<p>How about trying again?</p>
-			</div>
-			<button class="btn variant-filled-primary" on:click={handleTryAgain}>Try again</button>
+		<div class="text-center min-h-screen flex flex-col justify-center pb-32">
+			<InfoHeader emoji="🤕" heading="Something went wrong!" description="How about trying again?">
+				<button class="btn variant-filled-primary" on:click={handleTryAgain}>Reload</button>
+			</InfoHeader>
 		</div>
 	{:else if items.length === 0}
-		<div class="mt-8 text-center space-y-8 h-screen">
-			<div>
-				<p class="text-6xl">😲</p>
-				<h4>We've come up empty!</h4>
-				{#if recommendedSelected}
-					<p>
-						We can't find any books that match your genre preferences. Try changing your filters!
-					</p>
-				{:else}
-					<p>Try changing your filters or write your own book!</p>
+		<div class="text-center min-h-screen flex flex-col justify-center pb-32">
+			<InfoHeader
+				emoji="🤲"
+				heading="We're empty handed!"
+				description={recommendedSelected
+					? "We can't find any books that match your genre preferences. Try changing your filters!"
+					: 'Try changing your filters or write your own book!'}
+			>
+				{#if !recommendedSelected}
+					<a href="/book/create" class="btn variant-filled-primary">Start writing</a>
 				{/if}
-			</div>
-			{#if !recommendedSelected}
-				<a href="/book/create" class="btn variant-filled-primary">Start writing</a>
-			{/if}
+			</InfoHeader>
 		</div>
 	{:else}
 		<div class="min-h-screen">

--- a/src/routes/(landing)/library/+page.svelte
+++ b/src/routes/(landing)/library/+page.svelte
@@ -170,7 +170,7 @@
 
 <div class="flex min-h-screen relative w-full">
 	<div
-		class="min-h-screen rounded-xl m-2 sticky top-16 hidden sm:flex flex-col justify-between w-64 min-w-[16rem] bg-surface-100-800-token pt-4 pb-24 p-4 gap-2"
+		class="min-h-screen rounded-lg m-2 sticky top-16 hidden sm:flex flex-col justify-between w-64 min-w-[16rem] bg-surface-100-800-token pt-4 pb-24 p-4 gap-2"
 	>
 		<div class="flex flex-col gap-2">
 			{#each readingLists as list}
@@ -217,7 +217,7 @@
 	{:else if items.length === 0}
 		<InfoHeader
 			emoji="🤲"
-			heading="We've come up empty!"
+			heading="We're empty handed!"
 			description="This reading list is empty. Why not add some storylines to it?"
 		>
 			<a href="/home" class="btn variant-filled-primary">Browse books</a>

--- a/src/routes/(landing)/studio/+layout.svelte
+++ b/src/routes/(landing)/studio/+layout.svelte
@@ -3,9 +3,9 @@
 	import DrawerButton from '$lib/components/studio/DrawerButton.svelte';
 </script>
 
-<div class="flex w-full">
+<div class="flex w-full p-2 gap-2">
 	<div
-		class="min-h-screen rounded-xl m-2 sticky top-16 hidden sm:flex flex-col w-64 min-w-[16rem] bg-surface-100-800-token pt-4 pb-24 p-4 gap-2"
+		class="min-h-screen rounded-lg sticky top-16 hidden sm:flex flex-col w-64 min-w-[16rem] bg-surface-100-800-token pt-4 pb-24 p-4 gap-2"
 	>
 		<a
 			class="btn {$page.url.pathname === '/studio/books'

--- a/src/routes/(landing)/studio/books/+page.svelte
+++ b/src/routes/(landing)/studio/books/+page.svelte
@@ -28,6 +28,7 @@
 
 	let archiveMode: boolean = false;
 	let lastLoadEpoch = 0;
+	let selectedBooks: HydratedDocument<BookProperties>[] = [];
 
 	const bookDetailsModalComponent: ModalComponent = {
 		ref: BookDetails
@@ -65,30 +66,41 @@
 		  ) as HydratedDocument<BookProperties>[])
 		: [];
 
-	function openArchiveModal(book: HydratedDocument<BookProperties>) {
-		archiveModal.body = `Are you sure you want to archive ${book.title}?`;
+	function openArchiveModal(books: HydratedDocument<BookProperties>[]) {
+		if (books.length > 1) {
+			archiveModal.body = `Are you sure you want to archive these ${books.length} books? Doing so will archive all the storylines and chapters you've created for them too.`;
+		} else {
+			archiveModal.body = `Are you sure you want to archive ${books[0].title}? Doing so will archive all the storylines and chapters you've created for it too.`;
+		}
+
 		archiveModal.response = async (r: boolean) => {
 			if (r) {
-				await setArchive(book._id, true);
+				await setArchive(books, true);
 				refetch();
 			}
 		};
 		modalStore.trigger(archiveModal);
 	}
 
-	function openUnarchiveModal(book: HydratedDocument<BookProperties>) {
-		unArchiveModal.body = `Are you sure you want to unarchive ${book.title}?`;
+	function openUnarchiveModal(books: HydratedDocument<BookProperties>[]) {
+		if (books.length > 1) {
+			unArchiveModal.body = `Are you sure you want to unarchive these ${books.length} books? Doing so will unarchive all the storylines and chapters you've created for them too.`;
+		} else {
+			unArchiveModal.body = `Are you sure you want to unarchive ${books[0].title}? Doing so will unarchive all the storylines and chapters you've created for it too.`;
+		}
+
 		unArchiveModal.response = async (r: boolean) => {
 			if (r) {
-				await setArchive(book._id, false);
+				await setArchive(books, false);
 				refetch();
 			}
 		};
 		modalStore.trigger(unArchiveModal);
 	}
 
-	async function setArchive(id: string, archived: boolean) {
-		const resp = await trpc($page).books.setArchived.mutate({ id, archived });
+	async function setArchive(books: HydratedDocument<BookProperties>[], archived: boolean) {
+		const ids = books.map((b) => b._id);
+		const resp = await trpc($page).books.setArchived.mutate({ ids, archived });
 	}
 
 	function openCreateModal() {
@@ -134,19 +146,36 @@
 	async function refetch() {
 		$getBooksInfinite.remove();
 		await $getBooksInfinite.refetch();
+		selectedBooks = [];
+	}
+
+	function handleBookSelect(
+		e: Event & {
+			currentTarget: EventTarget & HTMLInputElement;
+		},
+		book: HydratedDocument<BookProperties>
+	) {
+		if ((e.target as HTMLInputElement).checked) {
+			if (!selectedBooks.includes(book)) {
+				selectedBooks = [...selectedBooks, book];
+			}
+		} else {
+			selectedBooks = selectedBooks.filter((s) => s !== book);
+		}
 	}
 </script>
 
 <svelte:window on:scroll={loadMore} />
 
 <div class="min-h-screen overflow-hidden w-full">
-	<div class="w-full min-h-screen flex flex-col gap-2 p-2">
+	<div class="w-full min-h-screen flex flex-col gap-2">
 		<DrawerButton />
 
 		<div class="table-container min-w-full">
-			<table class="table table-hover table-compact">
+			<table class="table table-hover table-compact relative">
 				<thead>
 					<tr>
+						<th />
 						<th>Cover</th>
 						<th>Title</th>
 						<th>Description</th>
@@ -156,10 +185,8 @@
 				</thead>
 				<tbody>
 					<tr>
-						<td colspan="5">
-							<div class="flex justify-end items-center p-1 gap-4 min-h-[42px]">
-								<ArchiveToggle bind:archiveMode />
-								<span class="divider-vertical h-6 mx-0" />
+						<td colspan="6">
+							<div class="flex sm:justify-start sm:flex-row-reverse items-center gap-2 sm:gap-4">
 								<button
 									type="button"
 									class="btn-icon btn-icon-sm variant-filled-primary"
@@ -167,18 +194,31 @@
 								>
 									<span><Icon data={plus} /></span>
 								</button>
+								<span class="divider-vertical h-6 mx-0" />
+								<ArchiveToggle bind:archiveMode />
+								<span class="divider-vertical h-6 mx-0" />
+								<button
+									class="btn btn-sm variant-filled"
+									disabled={selectedBooks.length === 0}
+									on:click={() =>
+										archiveMode
+											? openUnarchiveModal(selectedBooks)
+											: openArchiveModal(selectedBooks)}
+								>
+									{archiveMode ? 'Unarchive' : 'Archive'} Selected
+								</button>
 							</div>
 						</td>
 					</tr>
 					{#if $getBooksInfinite.isLoading}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<LoadingSpinner />
 							</td>
 						</tr>
 					{:else if $getBooksInfinite.isError}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<InfoHeader
 									emoji="🤕"
 									heading="Oops!"
@@ -188,10 +228,10 @@
 						</tr>
 					{:else if books.length === 0}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<InfoHeader
 									emoji="🤲"
-									heading="We've come up empty!"
+									heading="We're empty handed!"
 									description="It looks like you don't have any {archiveMode
 										? 'archived'
 										: 'unarchived'} books."
@@ -201,6 +241,13 @@
 					{:else}
 						{#each books as book}
 							<tr>
+								<td>
+									<input
+										class="checkbox"
+										type="checkbox"
+										on:change={(e) => handleBookSelect(e, book)}
+									/>
+								</td>
 								<td>
 									<StudioImage
 										src={book.imageURL}
@@ -218,8 +265,8 @@
 								<RowActions
 									{archiveMode}
 									editCallback={() => openEditModal(book)}
-									archiveCallback={() => openUnarchiveModal(book)}
-									unarchiveCallback={() => openArchiveModal(book)}
+									archiveCallback={() => openUnarchiveModal([book])}
+									unarchiveCallback={() => openArchiveModal([book])}
 								/>
 							</tr>
 						{/each}

--- a/src/routes/(landing)/studio/books/+page.svelte
+++ b/src/routes/(landing)/studio/books/+page.svelte
@@ -20,6 +20,7 @@
 	import BookModal from '$lib/components/book/BookModal.svelte';
 	import { debouncedScrollCallback } from '$lib/util/debouncedCallback';
 	import ScrollToTopButton from '$lib/components/util/ScrollToTopButton.svelte';
+	import ArchiveSelectedButton from '$lib/components/studio/ArchiveSelectedButton.svelte';
 
 	const archiveModal = getArchiveModal();
 	const unArchiveModal = getUnarchiveModal();
@@ -197,16 +198,12 @@
 								<span class="divider-vertical h-6 mx-0" />
 								<ArchiveToggle bind:archiveMode />
 								<span class="divider-vertical h-6 mx-0" />
-								<button
-									class="btn btn-sm variant-filled"
-									disabled={selectedBooks.length === 0}
-									on:click={() =>
-										archiveMode
-											? openUnarchiveModal(selectedBooks)
-											: openArchiveModal(selectedBooks)}
-								>
-									{archiveMode ? 'Unarchive' : 'Archive'} Selected
-								</button>
+								<ArchiveSelectedButton
+									selected={selectedBooks}
+									{archiveMode}
+									{openArchiveModal}
+									{openUnarchiveModal}
+								/>
 							</div>
 						</td>
 					</tr>

--- a/src/routes/(landing)/studio/chapters/+page.svelte
+++ b/src/routes/(landing)/studio/chapters/+page.svelte
@@ -27,6 +27,7 @@
 
 	let archiveMode: boolean = false;
 	let lastLoadEpoch = 0;
+	let selectedChapters: HydratedDocument<ChapterProperties>[] = [];
 
 	const chapterDetailsModalComponent: ModalComponent = {
 		ref: ChapterDetailsModal
@@ -60,30 +61,41 @@
 		  ) as HydratedDocument<HydratedChapterProperties>[])
 		: [];
 
-	function openArchiveModal(chapter: HydratedDocument<ChapterProperties>) {
-		archiveModal.body = `Are you sure you want to archive ${chapter.title}?`;
+	function openArchiveModal(chapters: HydratedDocument<ChapterProperties>[]) {
+		if (chapters.length > 1) {
+			archiveModal.body = `Are you sure you want to archive these ${chapters.length} chapters?`;
+		} else {
+			archiveModal.body = `Are you sure you want to archive ${chapters[0].title}?`;
+		}
+
 		archiveModal.response = async (r: boolean) => {
 			if (r) {
-				await setArchive(chapter._id, true);
+				await setArchive(chapters, true);
 				refetch();
 			}
 		};
 		modalStore.trigger(archiveModal);
 	}
 
-	function openUnarchiveModal(chapter: HydratedDocument<ChapterProperties>) {
-		unArchiveModal.body = `Are you sure you want to unarchive ${chapter.title}?`;
+	function openUnarchiveModal(chapters: HydratedDocument<ChapterProperties>[]) {
+		if (chapters.length > 1) {
+			unArchiveModal.body = `Are you sure you want to unarchive these ${chapters.length} chapters?`;
+		} else {
+			unArchiveModal.body = `Are you sure you want to unarchive ${chapters[0].title}?`;
+		}
+
 		unArchiveModal.response = async (r: boolean) => {
 			if (r) {
-				await setArchive(chapter._id, false);
+				await setArchive(chapters, false);
 				refetch();
 			}
 		};
 		modalStore.trigger(unArchiveModal);
 	}
 
-	async function setArchive(id: string, archived: boolean) {
-		const resp = await trpc($page).chapters.setArchived.mutate({ id, archived });
+	async function setArchive(chapters: HydratedDocument<ChapterProperties>[], archived: boolean) {
+		const ids = chapters.map((c) => c._id);
+		const resp = await trpc($page).chapters.setArchived.mutate({ ids, archived });
 	}
 
 	function openEditModal(chapter: HydratedDocument<ChapterProperties>) {
@@ -127,19 +139,36 @@
 	async function refetch() {
 		$getChaptersInfinite.remove();
 		await $getChaptersInfinite.refetch();
+		selectedChapters = [];
+	}
+
+	function handleChapterSelect(
+		e: Event & {
+			currentTarget: EventTarget & HTMLInputElement;
+		},
+		chapter: HydratedDocument<ChapterProperties>
+	) {
+		if ((e.target as HTMLInputElement).checked) {
+			if (!selectedChapters.includes(chapter)) {
+				selectedChapters = [...selectedChapters, chapter];
+			}
+		} else {
+			selectedChapters = selectedChapters.filter((s) => s !== chapter);
+		}
 	}
 </script>
 
 <svelte:window on:scroll={loadMore} />
 
 <div class="min-h-screen w-full overflow-hidden">
-	<div class="w-full min-h-screen flex flex-col gap-2 p-2">
+	<div class="w-full min-h-screen flex flex-col gap-2">
 		<DrawerButton />
 
 		<div class="table-container min-w-full">
 			<table class="table table-hover table-compact">
 				<thead>
 					<tr>
+						<th />
 						<th>Cover</th>
 						<th>Title</th>
 						<th>Storyline</th>
@@ -149,21 +178,32 @@
 				</thead>
 				<tbody>
 					<tr>
-						<td colspan="5">
-							<div class="flex justify-end items-center p-1 gap-4 min-h-[42px]">
+						<td colspan="6">
+							<div class="flex sm:justify-start sm:flex-row-reverse items-center gap-2 sm:gap-4">
 								<ArchiveToggle bind:archiveMode />
+								<span class="divider-vertical h-6 mx-0" />
+								<button
+									class="btn btn-sm variant-filled"
+									disabled={selectedChapters.length === 0}
+									on:click={() =>
+										archiveMode
+											? openUnarchiveModal(selectedChapters)
+											: openArchiveModal(selectedChapters)}
+								>
+									{archiveMode ? 'Unarchive' : 'Archive'} Selected
+								</button>
 							</div>
 						</td>
 					</tr>
 					{#if $getChaptersInfinite.isLoading}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<LoadingSpinner />
 							</td>
 						</tr>
 					{:else if $getChaptersInfinite.isError}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<InfoHeader
 									emoji="🤕"
 									heading="Oops!"
@@ -173,10 +213,10 @@
 						</tr>
 					{:else if chapters.length === 0}
 						<tr>
-							<td colspan="5">
+							<td colspan="6">
 								<InfoHeader
 									emoji="🤲"
-									heading="We've come up empty!"
+									heading="We're empty handed!"
 									description="It looks like you don't have any {archiveMode
 										? 'archived'
 										: 'unarchived'} chapters."
@@ -186,6 +226,13 @@
 					{:else}
 						{#each chapters as chapter}
 							<tr>
+								<td>
+									<input
+										class="checkbox"
+										type="checkbox"
+										on:change={(e) => handleChapterSelect(e, chapter)}
+									/>
+								</td>
 								<td>
 									<StudioImage
 										src={getImageURL(chapter) ?? ''}
@@ -203,8 +250,8 @@
 								<RowActions
 									{archiveMode}
 									editCallback={() => openEditModal(chapter)}
-									archiveCallback={() => openUnarchiveModal(chapter)}
-									unarchiveCallback={() => openArchiveModal(chapter)}
+									archiveCallback={() => openUnarchiveModal([chapter])}
+									unarchiveCallback={() => openArchiveModal([chapter])}
 								/>
 							</tr>
 						{/each}

--- a/src/routes/(landing)/studio/chapters/+page.svelte
+++ b/src/routes/(landing)/studio/chapters/+page.svelte
@@ -19,6 +19,7 @@
 	import { goto } from '$app/navigation';
 	import { debouncedScrollCallback } from '$lib/util/debouncedCallback';
 	import ScrollToTopButton from '$lib/components/util/ScrollToTopButton.svelte';
+	import ArchiveSelectedButton from '$lib/components/studio/ArchiveSelectedButton.svelte';
 
 	const archiveModal = getArchiveModal();
 	const unArchiveModal = getUnarchiveModal();
@@ -182,16 +183,12 @@
 							<div class="flex sm:justify-start sm:flex-row-reverse items-center gap-2 sm:gap-4">
 								<ArchiveToggle bind:archiveMode />
 								<span class="divider-vertical h-6 mx-0" />
-								<button
-									class="btn btn-sm variant-filled"
-									disabled={selectedChapters.length === 0}
-									on:click={() =>
-										archiveMode
-											? openUnarchiveModal(selectedChapters)
-											: openArchiveModal(selectedChapters)}
-								>
-									{archiveMode ? 'Unarchive' : 'Archive'} Selected
-								</button>
+								<ArchiveSelectedButton
+									selected={selectedChapters}
+									{archiveMode}
+									{openArchiveModal}
+									{openUnarchiveModal}
+								/>
 							</div>
 						</td>
 					</tr>

--- a/src/routes/(landing)/studio/storylines/+page.svelte
+++ b/src/routes/(landing)/studio/storylines/+page.svelte
@@ -18,6 +18,7 @@
 	import StorylineModal from '$lib/components/storyline/StorylineModal.svelte';
 	import ScrollToTopButton from '$lib/components/util/ScrollToTopButton.svelte';
 	import { debouncedScrollCallback } from '$lib/util/debouncedCallback';
+	import ArchiveSelectedButton from '$lib/components/studio/ArchiveSelectedButton.svelte';
 
 	const archiveModal = getArchiveModal();
 	const unArchiveModal = getUnarchiveModal();
@@ -180,16 +181,12 @@
 							<div class="flex sm:justify-start sm:flex-row-reverse items-center gap-2 sm:gap-4">
 								<ArchiveToggle bind:archiveMode />
 								<span class="divider-vertical h-6 mx-0" />
-								<button
-									class="btn btn-sm variant-filled"
-									disabled={selectedStorylines.length === 0}
-									on:click={() =>
-										archiveMode
-											? openUnarchiveModal(selectedStorylines)
-											: openArchiveModal(selectedStorylines)}
-								>
-									{archiveMode ? 'Unarchive' : 'Archive'} Selected
-								</button>
+								<ArchiveSelectedButton
+									selected={selectedStorylines}
+									{archiveMode}
+									{openArchiveModal}
+									{openUnarchiveModal}
+								/>
 							</div>
 						</td>
 					</tr>


### PR DESCRIPTION
## Summary

This PR improves UX and adds the ability for users to archive multiple books, storylines, or chapters at once.

## Details

### Direct

- Update APIs
    - books, storylines, and chapters APIs have been updated to accept an array of IDs, rather than a singular ID.
    - Database calls now filter for the relevant resource based on the occurrence of its ID in the given array of IDs.
    - The (un)archiving cascades as before.
- Update UI
    - The studio for each resource now features a checkbox for each row in the table and a button that archives/unarchives all the selected resources.
    - The wording for the archiving and unarchiving modals have been updated to better reflect the cascading effect for books and storylines.
- Update tests
    - The relevant books, storylines, and chapters tests have been updated to reflect the updated API.


### Collateral

- Add imageURL as part of test-data setup for storylines.
- Refactor `InfoHeader` component usages.

## Testing

- Manual UI/UX testing.
- Ran `pnpm test` - all tests passed.